### PR TITLE
Show the '<body>' in a script bug.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.0.3
+    - Fix issues with having <body> in a script tag above the real
+      body tag.
+1.0.2
+    - iOS8 smart banner fix
 1.0.1
     - Changes necessary for adaptive.js
     - Remove adaptive.js and loader.js from capture

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
 # capture.js
 
-A library for capturing your DOM. 
+A library for capturing your DOM.
 
 ## How to use
 
-Right now, there are no instructions on how to use capture.js
-standalone. Please go to www.mobifyjs.com for information
-on how to use capturing.
+Right now, there are no instructions on how to use capture.js standalone. Please
+go to www.mobifyjs.com for information on how to use capturing.
 
 ## How to create and ship a change
 
 First, install the dependancies:
 
-    $ npm install
-    $ bower install
+```bash
+npm install
+bower install
+```
 
-Then, run the following command to watch and build the capture.js file
-as you develop:
+Then, run the following command to watch and build the capture.js file as you
+develop:
 
-	$ grunt serve
+```bash
+grunt serve
+```
+
+Make sure you've got mobifyjs-utils installed!
 
 Then, do the following to ship the change:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capturejs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-browserify": "~1.3.1",

--- a/src/capture.js
+++ b/src/capture.js
@@ -307,7 +307,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
     // <body> inside a comment, common with IE conditional comments.
     // (using a "new RegExp" here because in Android 2.3 when you use a global
     // match using a RegExp literal, the state is incorrectly cached).
-    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|<script[^>]*?>(?:[\\s\\S]*?)</script>|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
+    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|<script(?:[^>\'"]*|\'[^\']*?\'|"[^"]*?")*>(?:[\\s\\S]*?)</script>|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
 
     //Fallback for absence of </head> and <body>
     var rawHTML = captured.bodyContent = captured.headContent + captured.bodyContent;

--- a/src/capture.js
+++ b/src/capture.js
@@ -307,7 +307,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
     // <body> inside a comment, common with IE conditional comments.
     // (using a "new RegExp" here because in Android 2.3 when you use a global
     // match using a RegExp literal, the state is incorrectly cached).
-    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
+    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|"(?:[\\s\\S]*?)"|\'<!--(?:[\\s\\S]*?)-->\'|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
 
     //Fallback for absence of </head> and <body>
     var rawHTML = captured.bodyContent = captured.headContent + captured.bodyContent;

--- a/src/capture.js
+++ b/src/capture.js
@@ -307,7 +307,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
     // <body> inside a comment, common with IE conditional comments.
     // (using a "new RegExp" here because in Android 2.3 when you use a global
     // match using a RegExp literal, the state is incorrectly cached).
-    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|"(?:[\\s\\S]*?)"|\'<!--(?:[\\s\\S]*?)-->\'|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
+    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|<script>(?:[\\s\\S]*?)</script>|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
 
     //Fallback for absence of </head> and <body>
     var rawHTML = captured.bodyContent = captured.headContent + captured.bodyContent;

--- a/src/capture.js
+++ b/src/capture.js
@@ -307,7 +307,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
     // <body> inside a comment, common with IE conditional comments.
     // (using a "new RegExp" here because in Android 2.3 when you use a global
     // match using a RegExp literal, the state is incorrectly cached).
-    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|<script>(?:[\\s\\S]*?)</script>|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
+    var bodySnatcher = new RegExp('<!--(?:[\\s\\S]*?)-->|<script[^>]*?>(?:[\\s\\S]*?)</script>|(<\\/head\\s*>|<body[\\s\\S]*$)', 'gi');
 
     //Fallback for absence of </head> and <body>
     var rawHTML = captured.bodyContent = captured.headContent + captured.bodyContent;

--- a/src/capture.js
+++ b/src/capture.js
@@ -6,7 +6,7 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        module.exports = factory(require('../../mobifyjs-utils/utils.js'), require('./patchAnchorLinks.js'));
+        module.exports = factory(require('../bower_components/mobifyjs-utils/utils.js'), require('./patchAnchorLinks.js'));
     } else {
         // Browser globals (root is window)
         root.Capture = factory(root.Utils, root.patchAnchorLinks);

--- a/src/patchAnchorLinks.js
+++ b/src/patchAnchorLinks.js
@@ -7,7 +7,7 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
-        var Utils = require('../../mobifyjs-utils/utils.js');
+        var Utils = require('../bower_components/mobifyjs-utils/utils.js');
         module.exports = factory(Utils);
     } else {
         // Browser globals (root is window)

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -191,7 +191,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
 
             var expectedCaptureClone = Utils.clone(expectedCapture);
 
-            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n    <script type=\"text/javascript\">\"<body foo=\"fail\">\"</script>\n</head>\n"
+            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n    <script type=\"text/javascript>\">\"<body foo=\"fail\">\"</script>\n</head>\n"
 
             var capture = Capture.createDocumentFragmentsStrings(doc);
 

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -90,9 +90,9 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
     }
 
     var captureCompare = function(actual, expected) {
-        ok(compareHTMLStrings(actual.headContent, expected.headContent), "head content matches");            
+        ok(compareHTMLStrings(actual.headContent, expected.headContent), "head content matches");
         ok(compareHTMLStrings(actual.bodyContent, expected.bodyContent), "body content matches");
-        
+
         var actualToCompare = $.extend({}, actual);
         delete actualToCompare.headContent;
         delete actualToCompare.bodyContent;
@@ -176,6 +176,32 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             captureCompare(capture, expectedCaptureClone)
             start();
         });
+        $("#qunit-fixture").append(iframe);
+    });
+
+    asyncTest("createDocumentFragmentsStrings - script with opening body", function() {
+        var iframe = $("<iframe>", {id: "plaintext-example5"});
+        iframe.attr("src", "/tests/fixtures/plaintext-script-with-opening-body.html")
+        iframe.one('load', function(){
+            var doc = this.contentDocument;
+
+            // @jb: I don't get this?
+            // We remove the webdriver attribute set when running tests on selenium (typically done through SauceLabs)
+            var htmlEl = doc.getElementsByTagName("html")[0].removeAttribute("webdriver")
+
+            var expectedCaptureClone = Utils.clone(expectedCapture);
+
+            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n"
+
+            var capture = Capture.createDocumentFragmentsStrings(doc);
+
+            // @jb: Cheat
+            expect(0);
+            // captureCompare(capture, expectedCaptureClone)
+
+            start();
+        });
+
         $("#qunit-fixture").append(iframe);
     });
 
@@ -293,7 +319,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
         $("#qunit-fixture").append($iframe);
     });
 
-    /* 
+    /*
      * Ensure that the mobify library is re-inserted into the
      * document, as well that the main function is inserted.
      */
@@ -315,9 +341,9 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
         $("#qunit-fixture").append($iframe);
     });
 
-    /* 
-     * Most browsers create a new global javascript namespace in the new document, 
-     * except webkit, which preserves the namespace as it was before the call to 
+    /*
+     * Most browsers create a new global javascript namespace in the new document,
+     * except webkit, which preserves the namespace as it was before the call to
      * document.open(). We reinject the library to ensure `Capture` can be used
      * after the namespace is cleared.
      */
@@ -364,7 +390,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
 
     asyncTest("Capture.restore", function(){
         var $iframe = $("<iframe>", {id: "plaintext-example201", src: "/tests/fixtures/plaintext-restore-example.html"});
-        var el = $iframe[0];  
+        var el = $iframe[0];
 
         var expectedHTML =
             '<!DOCTYPE HTML>' +
@@ -383,7 +409,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             if (event.source != el.contentWindow) return;
             window.removeEventListener("message", onMessage, false);
             var doc = el.contentDocument;
-            
+
             // Make sure that there are no meta tags in the document at all
             var html = Utils.getDoctype(doc) + Utils.outerHTML(doc.documentElement);
 

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -191,13 +191,14 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
 
             var expectedCaptureClone = Utils.clone(expectedCapture);
 
-            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n"
+            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n    <script>\"<body>\"</script>\n</head>\n"
 
             var capture = Capture.createDocumentFragmentsStrings(doc);
 
             // @jb: Cheat
-            expect(0);
-            // captureCompare(capture, expectedCaptureClone)
+            // We're not testing the all function here, let's remove it
+            delete capture.all;
+            captureCompare(capture, expectedCaptureClone)
 
             start();
         });

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -191,7 +191,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
 
             var expectedCaptureClone = Utils.clone(expectedCapture);
 
-            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n    <script>\"<body>\"</script>\n</head>\n"
+            expectedCaptureClone.headContent = "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n    <script type=\"text/javascript\">\"<body foo=\"fail\">\"</script>\n</head>\n"
 
             var capture = Capture.createDocumentFragmentsStrings(doc);
 

--- a/tests/fixtures/plaintext-script-with-opening-body.html
+++ b/tests/fixtures/plaintext-script-with-opening-body.html
@@ -1,13 +1,18 @@
-<!doctype html>
-<html>
-<head>
-    <script>
-        // Simulate mobify
-        document.write("<plaintext style=\"display:none\">");
-    </script>
+<!DOCTYPE html>
+<html class="testclass">
+<script>
+    // Simulate mobify
+    document.write("<plaintext style=\"display:none\">");
+</script>
+<head foo="bar">
+    
+    <link rel="stylesheet" href="/path/to/stylesheet.css">
     <script>"<body>"</script>
 </head>
-<body>
-    <h1>Will the real &lt;body&gt; please stand up?</h1>
+<body bar="baz">
+    <!-- comment with <head> -->
+    <p>Plaintext example page!</p>
+    <script src="/path/to/script.js"></script>
 </body>
 </html>
+

--- a/tests/fixtures/plaintext-script-with-opening-body.html
+++ b/tests/fixtures/plaintext-script-with-opening-body.html
@@ -7,7 +7,7 @@
 <head foo="bar">
     
     <link rel="stylesheet" href="/path/to/stylesheet.css">
-    <script>"<body>"</script>
+    <script type="text/javascript">"<body foo="fail">"</script>
 </head>
 <body bar="baz">
     <!-- comment with <head> -->

--- a/tests/fixtures/plaintext-script-with-opening-body.html
+++ b/tests/fixtures/plaintext-script-with-opening-body.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+    <script>
+        // Simulate mobify
+        document.write("<plaintext style=\"display:none\">");
+    </script>
+    <script>"<body>"</script>
+</head>
+<body>
+    <h1>Will the real &lt;body&gt; please stand up?</h1>
+</body>
+</html>

--- a/tests/fixtures/plaintext-script-with-opening-body.html
+++ b/tests/fixtures/plaintext-script-with-opening-body.html
@@ -7,7 +7,7 @@
 <head foo="bar">
     
     <link rel="stylesheet" href="/path/to/stylesheet.css">
-    <script type="text/javascript">"<body foo="fail">"</script>
+    <script type="text/javascript>">"<body foo="fail">"</script>
 </head>
 <body bar="baz">
     <!-- comment with <head> -->


### PR DESCRIPTION
@jansepar @tedtate 

Related to the Christies bug with a `<script>"body"</script>`.

## Testing

```shell
grunt serve &
open http://127.0.0.1:3000/tests/?testNumber=17
```

**References**
* https://mobify.atlassian.net/browse/CHRIS-516
* www.christies.com/artdigest