### PR TITLE
[DONT MERGE] Inject preview toolbar script

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -528,6 +528,29 @@ Capture.prototype.enabledHTMLString = Capture.prototype.escapedHTMLString = func
 };
 
 /**
+ * Inject the Preview Toolbar javascript file into the DOM.
+ *
+ * A script element will be added to the document that is passed in. It will be
+ * added after the very last child of 'body.
+ *
+ * If the 'mobify-toolbar' parameter is set to 'false', this will not modify
+ * the DOM at all and the toolbar will not show up. The toolbar is displayed
+ * by default if not set to hidden.
+ */
+Capture.injectPreviewHook = function(doc) {
+    if (window.Mobify.Preview) {
+        var showToolbar = window.Mobify.Preview.getParameter('toolbar') === 'true';
+        if (showToolbar) {
+            var hookScript = doc.createElement('script'),
+                body = doc.head || doc.getElementsByTagName('body')[0];
+
+            hookScript.src = '//preview.mobify.com/static/preview/js/preview-toolbar.js';
+            body.appendChild(hookScript);
+        }
+    }
+};
+
+/**
  * Rewrite the document with a new html string
  */
 Capture.prototype.render = function(htmlString) {
@@ -548,6 +571,7 @@ Capture.prototype.render = function(htmlString) {
         setTimeout(function(){
             doc.open("text/html", "replace");
             doc.write(enabledHTMLString);
+            Capture.injectPreviewHook(doc);
             doc.close();
         });
     };


### PR DESCRIPTION
Work in Progress
----------------

This is a first attempt (POC) to inject a toolbar script in preview mode that
will allow us to provide additional details for the previewing user. Initially,
this will most likely be a simple visual indicator that a preview bundle is
loaded and used. 

This relies on changes in [mobify/portal_app](https://github.com/mobify/portal_app)
that provide the hook script and the getting and setting of the `mobify-toolbar`
flag.

Status: **Opened for visibility**

Reviewers: **@tedtate @johnboxall**
JIRA: **https://mobify.atlassian.net/browse/RPC-8**