### PR TITLE
Switch to grunt-aws-s3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,32 +137,27 @@ module.exports = function(grunt) {
                 }
             }
         },
-        s3: {
-            options: {
-                access: "public-read",
-                headers: { "Cache-Control": "public,max-age=1800" }, // cache for 30 min
-                maxOperations: 6
-            },
+        aws_s3: {
             capturejs: {
                 options: {
                     bucket: 'mobify',
-                    gzip: true
+                    CacheControl: "public,max-age=1800", // cache for 30 min
                 },
-                upload: [
+                files: [
                     { // unminified dev build
-                        src: "build/capture.js",
+                        src: ["build/capture.js"],
                         dest: "capturejs/capture-<%= pkg.version %>.js",
                     },
                     { // unminified dev build to latest
-                        src: "build/capture.js",
+                        src: ["build/capture.js"],
                         dest: "capturejs/capture-latest.js",
                     },
                     { // minified production build
-                        src: "build/capture.min.js",
+                        src: ["build/capture.min.js"],
                         dest: "capturejs/capture-<%= pkg.version %>.min.js",
                     },
                     { // minified production build to latest
-                        src: "build/capture.min.js",
+                        src: ["build/capture.min.js"],
                         dest: "capturejs/capture-latest.min.js",
                     }
                 ]
@@ -172,15 +167,15 @@ module.exports = function(grunt) {
 
     grunt.loadNpmTasks('grunt-express');
     grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.loadNpmTasks('grunt-aws-s3');
     grunt.loadNpmTasks('grunt-saucelabs');
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-s3');
 
     grunt.registerTask('build', ['browserify', 'uglify']);
     grunt.registerTask('saucelabs', ['test', 'saucelabs-qunit']);
     grunt.registerTask('test', ['express', 'qunit']);
     grunt.registerTask('serve', ['build', 'express', 'watch']);
-    grunt.registerTask('deploy', ['s3']);
+    grunt.registerTask('deploy', ['build', 'aws_s3']);
 };

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.4",
   "devDependencies": {
     "grunt": "~0.4.0",
+    "grunt-aws-s3": "^0.14.0",
     "grunt-browserify": "~1.3.1",
     "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-express": "~0.3.6",
-    "grunt-s3": "0.2.0-alpha.3",
     "grunt-saucelabs": "8.3.2"
   }
 }


### PR DESCRIPTION
Status: **Opened for MERGE**

Reviewers: @donnielrt @fractaltheory @haroldtreen 
JIRA: [RTM-339](https://mobify.atlassian.net/browse/RTM-339)

## Changes
- Fixes deploy so we can push the latest capture.js to the CDN

## How to test-drive this PR
- Run `grunt deploy`, make sure the following are correct:
    - https://s3.amazonaws.com/mobify/capturejs/capture-1.0.4.js, https://s3.amazonaws.com/mobify/capturejs/capture-latest.js, https://s3.amazonaws.com/mobify/capturejs/capture-1.0.4.min.js, https://s3.amazonaws.com/mobify/capturejs/capture-latest.min.js