### PR TITLE
Adds failing capturing example for <head> tag in HTML comments.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.0.6
+    - Fixed issue where <!-- --> comments containing '<head>' created false
+      positives when looking for the <head> section in HTML
 1.0.5
     - iOS8+ scroll fix is applied only when rendering an adapted document,
       resolving an issue with meta viewport tags and restored documents (PR #11)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "capturejs",
-    "version": "1.0.3",
+    "version": "1.0.6",
     "main": "build/capture.min.js",
     "dependencies": {
         "mobifyjs-utils": "git://github.com/mobify/mobifyjs-utils.git#1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-capturejs",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-aws-s3": "^0.14.0",

--- a/src/capture.js
+++ b/src/capture.js
@@ -262,6 +262,14 @@ Capture.setElementContentFromString = function(el, htmlString) {
 };
 
 /**
+ * Remove <head> tags within HTML comments, which would otherwise return false
+ * positives for `captured.headContent`
+ */
+Capture.removeCommentedHeadEls = function(str) {
+    return str.replace(new RegExp('<!--[\\s\\S]*<head>[^>]*-->'), '');
+};
+
+/**
  * Returns an object containing the state of the original page. Caches the object
  * in `extractedHTML` for later use.
  */
@@ -335,7 +343,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
         // <head foo="bar">
         // <!-- <head> begin -->
         // <plaintext>
-        captured.headContent = captured.headContent.replace(new RegExp('<!--[\\s\\S]*<head>[^>]*-->'), '');
+        captured.headContent = Capture.removeCommentedHeadEls(captured.headContent);
 
         // Edgecase: `capture.headContent` contains `<head>` if Tag is placed
         // before <head>.

--- a/src/capture.js
+++ b/src/capture.js
@@ -266,7 +266,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
  * positives for `captured.headContent`
  */
 Capture.removeCommentedHeadEls = function(str) {
-    return str.replace(new RegExp('<!--[\\s\\S]*<head>[^>]*-->'), '');
+    return str.replace(new RegExp('<!--[\\s\\S]*<head([\\s].*)?>[^>]*-->'), '');
 };
 
 /**

--- a/src/capture.js
+++ b/src/capture.js
@@ -266,7 +266,7 @@ Capture.setElementContentFromString = function(el, htmlString) {
  * positives for `captured.headContent`
  */
 Capture.removeCommentedHeadEls = function(str) {
-    return str.replace(new RegExp('<!--[\\s\\S]*<head([\\s].*)?>[^>]*-->'), '');
+    return str.replace(new RegExp('<!--[\\s\\S]*<head([\\s].*)?>.*-->'), '');
 };
 
 /**

--- a/src/capture.js
+++ b/src/capture.js
@@ -328,6 +328,15 @@ Capture.setElementContentFromString = function(el, htmlString) {
         // <head> content should be everything before this.
         captured.headContent = rawHTML.slice(0, match.index);
 
+        // Ensure that there are no comment tags with <head> in them,
+        // or the following setup will cause problems:
+        //
+        // <html>
+        // <head foo="bar">
+        // <!-- <head> begin -->
+        // <plaintext>
+        captured.headContent = captured.headContent.replace(new RegExp('<!--[\\s\\S]*<head>[^>]*-->'), '');
+
         // Edgecase: `capture.headContent` contains `<head>` if Tag is placed
         // before <head>.
         //

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -166,8 +166,6 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             // We're not testing the all function here, let's remove it
             delete capture.all;
             captureCompare(capture, expectedCapture);
-            console.dir(capture);
-            console.dir(expectedCapture);
 
             start();
         });

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -133,7 +133,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             htmlOpenTag: "<html class=\"testclass\">",
             headOpenTag: "<head foo=\"bar\">",
             bodyOpenTag: "<body bar=\"baz\">",
-            headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n</head>\n",
+            headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n<!-- </head> end -->\n</head>\n",
             bodyContent: "\n    <!-- comment with <head> -->\n    <p>Plaintext example page!</p>\n    <script src=\"/path/to/script.js\"><\/script>\n</body>\n</html>\n\n"
         };
         var iframe = $("<iframe>", {id: "plaintext-head-in-comment"});
@@ -146,6 +146,8 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             // We're not testing the all function here, let's remove it
             delete capture.all;
             captureCompare(capture, expectedCapture);
+            console.dir(capture);
+            console.dir(expectedCapture);
 
             start();
         });

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -133,7 +133,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             htmlOpenTag: "<html class=\"testclass\">",
             headOpenTag: "<head foo=\"bar\">",
             bodyOpenTag: "<body bar=\"baz\">",
-            headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n<!-- </head> end -->\n</head>\n",
+            headContent: "\n\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n<!-- </head> end -->\n</head>\n",
             bodyContent: "\n    <!-- comment with <head> -->\n    <p>Plaintext example page!</p>\n    <script src=\"/path/to/script.js\"><\/script>\n</body>\n</html>\n\n"
         };
         var iframe = $("<iframe>", {id: "plaintext-head-in-comment"});

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -137,7 +137,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             "<head>\n\n<!-- <head blah blah>some text --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <header>some text --></head>": "<head>\n\n<!-- <header>some text --></head>",
             // Ignore the <head> in the comment if it's closed
-            "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n<!-- <head>some text</head> --></head>"
+            "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n</head>"
         };
 
         for (var key in expectedResults) {

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -126,6 +126,23 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
         deepEqual(actualToCompare, expectedToCompare);
     }
 
+    test("removeCommentedHeadEls", function() {
+        var expectedResults = {
+            "<head></head>": "<head></head>",
+            "<head>\n\n<!-- some text --></head>": "<head>\n\n<!-- some text --></head>",
+            "<head>\n\n<!-- <head>some text --></head>": "<head>\n\n</head>",
+            "<head>\n\n<!-- <head blah blah>some text --></head>": "<head>\n\n</head>",
+            "<head>\n\n<!-- <header>some text --></head>": "<head>\n\n<!-- <header>some text --></head>",
+            "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n</head>",
+            "<body>\n\n<!-- <head>some text</head> --></body>": "<body>\n\n<!-- <head>some text</head> --></body>",
+        };
+
+        for (var key in expectedResults) {
+            if (expectedResults.hasOwnProperty(key)) {
+                equal(Capture.removeCommentedHeadEls(key), expectedResults[key]);
+            }
+        }
+    });
 
     asyncTest("createDocumentFragmentsStrings - head in comment tag", function() {
         var expectedCapture = {

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -136,7 +136,6 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             "<head>\n\n<!-- some text <head> --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <head blah blah>some text --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <header>some text --></head>": "<head>\n\n<!-- <header>some text --></head>",
-            // Ignore the <head> in the comment if it's closed
             "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n</head>"
         };
 

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -109,7 +109,7 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
         bodyOpenTag: "<body bar=\"baz\">",
         headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n</head>\n",
         bodyContent: "\n    <!-- comment with <head> -->\n    <p>Plaintext example page!</p>\n    <script src=\"/path/to/script.js\"><\/script>\n</body>\n</html>\n\n"
-    }
+    };
 
     var captureCompare = function(actual, expected) {
         ok(compareHTMLStrings(actual.headContent, expected.headContent), "head content does not match");
@@ -127,30 +127,50 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
     }
 
 
-    asyncTest("createDocumentFragmentsStrings - <head> in HTML comment", function() {
-        var expected = {
+    asyncTest("createDocumentFragmentsStrings - head in comment tag", function() {
+        var expectedCapture = {
             doctype: "<!DOCTYPE HTML>",
-            htmlOpenTag: "<html>",
-            headOpenTag: "<head>",
-            bodyOpenTag: "<body>",
-            headContent: "<!-- TODO -->",
-            bodyContent: ""
+            htmlOpenTag: "<html class=\"testclass\">",
+            headOpenTag: "<head foo=\"bar\">",
+            bodyOpenTag: "<body bar=\"baz\">",
+            headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n</head>\n",
+            bodyContent: "\n    <!-- comment with <head> -->\n    <p>Plaintext example page!</p>\n    <script src=\"/path/to/script.js\"><\/script>\n</body>\n</html>\n\n"
         };
-
-
         var iframe = $("<iframe>", {id: "plaintext-head-in-comment"});
         iframe.attr("src", "/tests/fixtures/plaintext-head-in-comment.html")
         iframe.one('load', function() {
             var doc = this.contentDocument;
-
             // We remove the webdriver attribute set when running tests on selenium (typically done through SauceLabs)
             var htmlEl = doc.getElementsByTagName("html")[0].removeAttribute("webdriver")
-            // alert(doc.getElementsByTagName("html")[0].innerHTML);
             var capture = Capture.createDocumentFragmentsStrings(doc);
             // We're not testing the all function here, let's remove it
             delete capture.all;
+            captureCompare(capture, expectedCapture);
 
-            captureCompare(capture, expected);
+            start();
+        });
+        $("#qunit-fixture").append(iframe);
+    });
+
+    asyncTest("createDocumentFragmentsStrings - body in comment tag", function() {
+        var expectedCapture = {
+            doctype: "<!DOCTYPE HTML>",
+            htmlOpenTag: "<html class=\"testclass\">",
+            headOpenTag: "<head foo=\"bar\">",
+            bodyOpenTag: "<body bar=\"baz\">",
+            headContent: "\n    \n    <link rel=\"stylesheet\" href=\"/path/to/stylesheet.css\">\n</head>\n<!-- <body class=\"bad\"> -->\n",
+            bodyContent: "\n    <!-- comment with <head> -->\n    <p>Plaintext example page!</p>\n    <script src=\"/path/to/script.js\"><\/script>\n</body>\n</html>\n\n"
+        };
+        var iframe = $("<iframe>", {id: "plaintext-body-in-comment"});
+        iframe.attr("src", "/tests/fixtures/plaintext-body-in-comment.html")
+        iframe.one('load', function() {
+            var doc = this.contentDocument;
+            // We remove the webdriver attribute set when running tests on selenium (typically done through SauceLabs)
+            var htmlEl = doc.getElementsByTagName("html")[0].removeAttribute("webdriver")
+            var capture = Capture.createDocumentFragmentsStrings(doc);
+            // We're not testing the all function here, let's remove it
+            delete capture.all;
+            captureCompare(capture, expectedCapture);
 
             start();
         });

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -133,8 +133,8 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
             "<head>\n\n<!-- <head>some text --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <head blah blah>some text --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <header>some text --></head>": "<head>\n\n<!-- <header>some text --></head>",
-            "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n</head>",
-            "<body>\n\n<!-- <head>some text</head> --></body>": "<body>\n\n<!-- <head>some text</head> --></body>",
+            // Ignore the <head> in the comment if it's closed
+            "<head>\n\n<!-- <head>some text</head> --></head>": "<head>\n\n<!-- <head>some text</head> --></head>"
         };
 
         for (var key in expectedResults) {

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -112,8 +112,8 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
     }
 
     var captureCompare = function(actual, expected) {
-        ok(compareHTMLStrings(actual.headContent, expected.headContent), "head content matches");
-        ok(compareHTMLStrings(actual.bodyContent, expected.bodyContent), "body content matches");
+        ok(compareHTMLStrings(actual.headContent, expected.headContent), "head content does not match");
+        ok(compareHTMLStrings(actual.bodyContent, expected.bodyContent), "body content does not match");
 
         var actualToCompare = $.extend({}, actual);
         delete actualToCompare.headContent;
@@ -125,6 +125,37 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
 
         deepEqual(actualToCompare, expectedToCompare);
     }
+
+
+    asyncTest("createDocumentFragmentsStrings - <head> in HTML comment", function() {
+        var expected = {
+            doctype: "<!DOCTYPE HTML>",
+            htmlOpenTag: "<html>",
+            headOpenTag: "<head>",
+            bodyOpenTag: "<body>",
+            headContent: "<!-- TODO -->",
+            bodyContent: ""
+        };
+
+
+        var iframe = $("<iframe>", {id: "plaintext-head-in-comment"});
+        iframe.attr("src", "/tests/fixtures/plaintext-head-in-comment.html")
+        iframe.one('load', function() {
+            var doc = this.contentDocument;
+
+            // We remove the webdriver attribute set when running tests on selenium (typically done through SauceLabs)
+            var htmlEl = doc.getElementsByTagName("html")[0].removeAttribute("webdriver")
+            // alert(doc.getElementsByTagName("html")[0].innerHTML);
+            var capture = Capture.createDocumentFragmentsStrings(doc);
+            // We're not testing the all function here, let's remove it
+            delete capture.all;
+
+            captureCompare(capture, expected);
+
+            start();
+        });
+        $("#qunit-fixture").append(iframe);
+    });
 
     asyncTest("createDocumentFragmentsStrings - below head tag", function() {
         var iframe = $("<iframe>", {id: "plaintext-example9"});

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -129,8 +129,11 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
     test("removeCommentedHeadEls", function() {
         var expectedResults = {
             "<head></head>": "<head></head>",
+            "<head>": "<head>",
             "<head>\n\n<!-- some text --></head>": "<head>\n\n<!-- some text --></head>",
             "<head>\n\n<!-- <head>some text --></head>": "<head>\n\n</head>",
+            "<head>\n\n<!-- <head> --><!-- <head> --></head>": "<head>\n\n</head>",
+            "<head>\n\n<!-- some text <head> --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <head blah blah>some text --></head>": "<head>\n\n</head>",
             "<head>\n\n<!-- <header>some text --></head>": "<head>\n\n<!-- <header>some text --></head>",
             // Ignore the <head> in the comment if it's closed
@@ -138,9 +141,10 @@ require(["mobifyjs/utils", "capture"], function(Utils, Capture) {
         };
 
         for (var key in expectedResults) {
-            if (expectedResults.hasOwnProperty(key)) {
-                equal(Capture.removeCommentedHeadEls(key), expectedResults[key]);
+            if (!expectedResults.hasOwnProperty(key)) {
+                return;
             }
+            equal(Capture.removeCommentedHeadEls(key), expectedResults[key]);
         }
     });
 

--- a/tests/fixtures/plaintext-body-in-comment.html
+++ b/tests/fixtures/plaintext-body-in-comment.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html class="testclass">
-<!-- <head> -->
 <script>
     // Simulate mobify
     document.write("<plaintext style=\"display:none\">");
 </script>
+<!-- test comment -->
 <head foo="bar">
+
     <link rel="stylesheet" href="/path/to/stylesheet.css">
 </head>
+<!-- <body class="bad"> -->
 <body bar="baz">
     <!-- comment with <head> -->
     <p>Plaintext example page!</p>

--- a/tests/fixtures/plaintext-head-in-comment.html
+++ b/tests/fixtures/plaintext-head-in-comment.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html class="testclass">
-<!-- <head> -->
-<script>
-    // Simulate mobify
-    document.write("<plaintext style=\"display:none\">");
-</script>
 <head foo="bar">
+<!-- <head> begin -->
+    <script>
+        // Simulate mobify
+        document.write("<plaintext style=\"display:none\">");
+    </script>
     <link rel="stylesheet" href="/path/to/stylesheet.css">
+<!-- </head> end -->
 </head>
 <body bar="baz">
     <!-- comment with <head> -->

--- a/tests/fixtures/plaintext-head-in-comment.html
+++ b/tests/fixtures/plaintext-head-in-comment.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- <head> -->
+    <meta name="content" content="I shouldn't be in the body.">
+    <script>document.write("<plaintext style=\"display:none\">");</script>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
@donnielrt here is an exciting one for you via @Helen-Mobify : )

The bug is in an edgecase introduced by this edgecase :) 

* https://github.com/mobify/capturejs/blob/master/src/capture.js#L331-L332

Essentially, we need to identify whether the `<head>` tag we're detecting is part of a HTML comment or not. If it is, we shouldn't count it.

