### PR TITLE
DO NOT MERGE & DO NOT DELETE - Capturejs investigation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
         watch: {
             files: ["src/**/*.js"
             ],
-            tasks: ['build'],
+            tasks: ['build','capturejs','captureminjs'],
         },
         'saucelabs-qunit': {
             capturejs: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,6 +183,22 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-watch');
 
+    // Copy capture.js to improvements app folder
+    grunt.registerTask('capturejs', function() {
+        var path = 'build/capture.js';
+        if (grunt.file.exists(path)) {
+            grunt.file.copy(path, '../%PROJECT%/capture.js');
+        }
+    });
+
+    // Copy capture.min.js to improvements app folder
+    grunt.registerTask('captureminjs', function() {
+        var path = 'build/capture.min.js';
+        if (grunt.file.exists(path)) {
+            grunt.file.copy(path, '../%PROJECT%/capture.min.js');
+        }
+    });
+
     grunt.registerTask('build', ['browserify', 'uglify']);
     grunt.registerTask('saucelabs', ['test', 'saucelabs-qunit']);
     grunt.registerTask('test', ['build', 'express:test', 'qunit']);

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "version": "1.0.6",
     "main": "build/capture.min.js",
     "dependencies": {
-        "mobifyjs-utils": "git://github.com/mobify/mobifyjs-utils.git#1.0.0"
+        "mobifyjs-utils": "git://github.com/mobify/mobifyjs-utils.git#dom-ready-check"
     },
     "ignore": [
         "tests",


### PR DESCRIPTION
# DO NOT MERGE & DO NOT DELETE

We are suspecting Safari mobile not allowing to `document.open`, `document.write`, and `document.close` when `document.readyState =`interactive'`. We are relying on this check to start capturing document in Capturejs
# CHANGES
- This copies the capturejs to a local project folder specified by `%PROJECT%`
- Pin mobfyjs-utils to the dom-ready-check branch https://github.com/mobify/mobifyjs-utils/pull/2
