### PR TITLE
Remove plaintext element _after_ capture.initCapture callback has bee…

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -128,11 +128,16 @@ Capture.init = Capture.initCapture = function(callback, doc, prefix) {
         Utils.extend(capture, capturedStringFragments);
         var capturedDOMFragments = capture.createDocumentFragments();
         Utils.extend(capture, capturedDOMFragments);
-        var plaintextEl = capture.sourceDoc.querySelector('plaintext')
-        if (plaintextEl) {
-            plaintextEl.parentNode.removeChild(plaintextEl)
+        try {
+            callback(capture);
+        } finally {
+            // Remove plaintext element after Capture.initCapture() callback
+            // has been called, and be robust in case of exceptions
+            var plaintextEl = capture.sourceDoc.querySelector('plaintext')
+            if (plaintextEl) {
+                plaintextEl.parentNode.removeChild(plaintextEl)
+            }
         }
-        callback(capture);
     };
 
     if (Utils.domIsReady(doc)) {

--- a/tests/capture-tests.js
+++ b/tests/capture-tests.js
@@ -95,25 +95,29 @@ require(["saucelabs-config", "qunit", "mobifyjs/utils", "capture"], function(_, 
             ok(compareHTMLStrings(plaintextText, expectedPlaintext), "plaintext is added")
 
             Capture.init(function(capture) {
-                var capturedDoc = capture.capturedDoc;
+                // wait for a turn of the event loop to see the removed 
+                // <plaintext> element
+                setTimeout(function() {
+                    var capturedDoc = capture.capturedDoc;
 
-                var expectedHtml =
-                    "<!DOCTYPE HTML>" +
-                    "<html class=testclass>" +
-                    "<head foo=bar>" +
-                    "    <link rel=stylesheet href=/path/to/stylesheet.css>" +
-                    "</head>" +
-                    "<body bar=baz>" +
-                    "  <!-- comment with <head> -->" +
-                    "  <p>Plaintext example page!</p>" +
-                    "  <script src=/path/to/script.js><\/script>" +
-                    "</body>" +
-                    "</html>";
+                    var expectedHtml =
+                        "<!DOCTYPE HTML>" +
+                        "<html class=testclass>" +
+                        "<head foo=bar>" +
+                        "    <link rel=stylesheet href=/path/to/stylesheet.css>" +
+                        "</head>" +
+                        "<body bar=baz>" +
+                        "  <!-- comment with <head> -->" +
+                        "  <p>Plaintext example page!</p>" +
+                        "  <script src=/path/to/script.js><\/script>" +
+                        "</body>" +
+                        "</html>";
 
-                var html = capture.enabledHTMLString(capturedDoc);
-                ok(doc.querySelector('plaintext') === null, "plaintext is removed")
-                ok(compareHTMLStrings(html, expectedHtml), "Passed!");
-                start();
+                    var html = capture.enabledHTMLString(capturedDoc);
+                    ok(doc.querySelector('plaintext') === null, "plaintext is removed")
+                    ok(compareHTMLStrings(html, expectedHtml), "Passed!");
+                    start();
+                }, 0);
             }, doc);
 
             ok(doc.querySelector('plaintext') === null, "plaintext is removed")
@@ -555,8 +559,12 @@ require(["saucelabs-config", "qunit", "mobifyjs/utils", "capture"], function(_, 
             var plaintextText = plaintextEl.innerText || plaintextEl.innerHTML
             ok(compareHTMLStrings(plaintextText, expectedPlaintext), 'plaintext added')
             Capture.init(function(capture) {
-                ok(doc.querySelector('plaintext') === null, "plaintext is removed")
-                capture.restore('<script>parent.postMessage("done!", "*");<\/script>');
+                // wait for a turn of the event loop to see the removed 
+                // <plaintext> element
+                setTimeout(function() {
+                    ok(doc.querySelector('plaintext') === null, "plaintext is removed")
+                    capture.restore('<script>parent.postMessage("done!", "*");<\/script>');
+                }, 0);
             }, doc);
             ok(doc.querySelector('plaintext') === null, 'plaintext is removed')
         });
@@ -588,14 +596,18 @@ require(["saucelabs-config", "qunit", "mobifyjs/utils", "capture"], function(_, 
             var plaintextText = plaintextEl.innerText || plaintextEl.innerHTML
             ok(compareHTMLStrings(plaintextText, expectedPlaintext), "plaintext added")
             Capture.init(function(capture) {
-                var capturedDoc = capture.capturedDoc;
+                // wait for a turn of the event loop to see the removed 
+                // <plaintext> element
+                setTimeout(function() {
+                    var capturedDoc = capture.capturedDoc;
 
-                var bodyChildren = capturedDoc.body.children;
-                ok(doc.querySelector('plaintext') === null, 'plaintext is removed')
-                equal(bodyChildren.length, 2);
-                equal(bodyChildren[0].nodeName, 'FORM', 'first child element is a form');
-                equal(bodyChildren[1].nodeName, 'FORM', 'second child element is a form');
-                start();
+                    var bodyChildren = capturedDoc.body.children;
+                    ok(doc.querySelector('plaintext') === null, 'plaintext is removed')
+                    equal(bodyChildren.length, 2);
+                    equal(bodyChildren[0].nodeName, 'FORM', 'first child element is a form');
+                    equal(bodyChildren[1].nodeName, 'FORM', 'second child element is a form');
+                    start();
+                }, 0);
             }, doc);
             ok(doc.querySelector('plaintext') === null, 'plaintext is removed')
         });


### PR DESCRIPTION
…n called to avoid conflicting with customer code that removes the tag itself, adjust tests